### PR TITLE
nsdiff & nsvi: add an option to specify the target server of the update request.

### DIFF
--- a/nsdiff
+++ b/nsdiff
@@ -225,7 +225,7 @@ nsdiff - create "nsupdate" script from DNS zone file differences
 
 nsdiff [B<-hV>] [B<-b> I<address>] [B<-k> I<keyfile>] [B<-y> [I<hmac>:]I<name>:I<key>]
        [B<-0>|B<-1>] [B<-q>|B<-v> [q][r]] [B<-cdD>] [B<-i> I<regex>] [B<-S> I<mode>|I<num>]
-       [B<-u>] [B<-s> I<server>] [B<-m> I<server>] <I<zone>> [I<old>] [I<new>]
+       [B<-u> I<server>] [B<-s> I<server>] [B<-m> I<server>] <I<zone>> [I<old>] [I<new>]
 
 =head1 DESCRIPTION
 
@@ -323,10 +323,11 @@ incremented. Serial number wrap-around is not supported.
 Quiet / quick check. Output is suppressed unless the zones differ, in
 which case a short note is printed instead of an B<nsupdate> script.
 
-=item B<-u>
+=item B<-u> I<server>[#I<port>]
 
-Tell B<nsupdate> to send the update message to the server specified in the
-B<-s> option.
+Tell B<nsupdate> to send the update message to the server specified in
+this option or, if the provided value is '-', to the server specified in
+the B<-s> option.
 
 =item B<-v> [q][r]
 

--- a/nsdiff
+++ b/nsdiff
@@ -29,28 +29,28 @@ usage: nsdiff [options] <zone> [old] [new]
   If the "old" file is omitted and there is no -s option, `nsdiff`
   will AXFR the zone from the server in the zone's SOA MNAME field.
 options:
-  -h                  display full documentation
-  -V                  display version information
-  -0                  allow a domain's updates to span packets
-  -1                  abort if update doesn't fit in one packet
-  -c                  compare records case-insensitively
-  -d                  ignore DS records
-  -D                  do not ignore DNSKEY records
-  -i regex            ignore records matching the pattern
-  -m server[#port]    from where to AXFR new version of the zone
-  -s server[#port]    from where to AXFR old version of the zone
-  -S num|mode         SOA serial number or update mode
-  -q                  only output if zones differ
-  -u                  tell nsupdate to send to -s server
-  -v [q][r]           verbose query and/or reply
-  -b address          AXFR query source address
-  -k keyfile          AXFR query TSIG key
-  -y [hmac:]name:key  AXFR query TSIG key
+  -h                   display full documentation
+  -V                   display version information
+  -0                   allow a domain's updates to span packets
+  -1                   abort if update doesn't fit in one packet
+  -c                   compare records case-insensitively
+  -d                   ignore DS records
+  -D                   do not ignore DNSKEY records
+  -i regex             ignore records matching the pattern
+  -m server[#port]     from where to AXFR new version of the zone
+  -s server[#port]     from where to AXFR old version of the zone
+  -S num|mode          SOA serial number or update mode
+  -q                   only output if zones differ
+  -u [-|server[#port]] where to send update version of the zone
+  -v [q][r]            verbose query and/or reply
+  -b address           AXFR query source address
+  -k keyfile           AXFR query TSIG key
+  -y [hmac:]name:key   AXFR query TSIG key
 EOF
     exit 2;
 }
 my %opt;
-usage unless getopts '-hV01cdDi:m:s:S:quv:b:k:y:', \%opt;
+usage unless getopts '-hV01cdDi:m:s:S:qu:v:b:k:y:', \%opt;
 version if $opt{V};
 exec "perldoc -F $0" if $opt{h};
 usage if @ARGV < 1 || @ARGV > 3;
@@ -65,7 +65,8 @@ wail "ignoring -m option when loading new zone from file"
     if $opt{m} && @ARGV > 1;
 fail "need -m option when there are no input files"
     unless $opt{m} || @ARGV > 1;
-usage if $opt{u} && !$opt{s};
+usage if $opt{u} eq "-" && !$opt{s};
+$opt{u} = $opt{s} if $opt{u} eq "-";
 
 usage if $opt{q} && $opt{v};
 usage if $opt{v} && $opt{v} !~ m{^[qr]*$};
@@ -200,7 +201,7 @@ while (@script) {
     $length += length $script[$i++] while $length < $maxlen and $i < @script;
     my @batch = splice @script, 0, $length < $maxlen ? $i : $i - 1;
     fail "update does not fit in packet" if @batch == 0 or $opt{1} and @script != 0;
-    print "server $opt{s}\n" if $opt{u};
+    print "server $opt{u}\n" if $opt{u};
     $soa =~ $soare;
     print "prereq yxrrset $zone $2 $3 $4";
     my $serial = $3 >= $soamin ? $3 + 1 : $soamin;

--- a/nsvi
+++ b/nsvi
@@ -30,14 +30,15 @@ nsvi options:
   -v                  turn on verbose output
   -01cdD              nsdiff options
   -S num|mode         SOA serial number or mode
-  -s server[#port]    where to AXFR and UPDATE the zone
+  -s server[#port]    where to AXFR and eventually UPDATE the zone
+  -t server[#port]    where to UPDATE the zone
   -k keyfile          AXFR and UPDATE TSIG key
   -y [hmac:]name:key  AXFR and UPDATE TSIG key
 EOF
     exit 1;
 }
 my %opt;
-usage unless getopts '-hV01cdDk:s:S:vy:', \%opt;
+usage unless getopts '-hV01cdDk:s:S:t:vy:', \%opt;
 version if $opt{V};
 exec "perldoc -F $0" if $opt{h};
 usage if @ARGV != 1;
@@ -61,7 +62,8 @@ push @nsdiff, map "-$_",
     grep $opt{$_}, qw{0 1 c d D};
 push @nsdiff, map "-$_$opt{$_}",
     grep $opt{$_}, qw{k s S v y};
-push @nsdiff, "-u" if $opt{s};
+push @nsdiff, "-u $opt{t}" if $opt{t};
+push @nsdiff, "-u -" if $opt{s} && !$opt{t};
 
 my @nsupdate = qw{nsupdate};
 push @nsupdate, map "-$_$opt{$_}",

--- a/nsvi
+++ b/nsvi
@@ -139,7 +139,7 @@ nsvi - transfer a zone, edit it, then upload the edits
 =head1 SYNOPSIS
 
 nsvi [B<-01cdDhvV>] [B<-k> I<keyfile>] [B<-y> [I<hmac>:]I<name>:I<key>]
-     [B<-S> I<mode>|I<num>] [B<-s> I<server>] <I<zone>>
+     [B<-S> I<mode>|I<num>] [B<-s> I<server>] [B<-t> I<server>] <I<zone>>
 
 =head1 DESCRIPTION
 
@@ -185,6 +185,10 @@ or IP address, optionally followed by a "#" and the port number.
 If you do not use the B<-s> option, the zone will be transferred
 from I<localhost>, and B<nsvi> will use B<nsupdate> B<-l> to update
 the zone.
+
+=item B<-t> I<server>[#I<port>]
+
+Send the update request to the server given in this option instead of the one given in B<-s>.
 
 =item B<-k> I<keyfile>
 


### PR DESCRIPTION
Hi,

These patches add a new functionality that seems missing to me (and that I need (-:): to be able to explicitly specify the server to send the updates to.

In my setup, nsdiff's option -u is not ideal, I do not want to send the update to the server given with -s, it is just the server I use to fetch the zone. The syntax I came up with is a bit weird, and I'm not particularly attached to it.

What do you think ?
