### PR TITLE
nsvi: forward -g to nsupdate

### DIFF
--- a/nsvi
+++ b/nsvi
@@ -35,11 +35,12 @@ nsvi options:
   -s server[#port]    where to AXFR and UPDATE the zone
   -k keyfile          AXFR and UPDATE TSIG key
   -y [hmac:]name:key  AXFR and UPDATE TSIG key
+  -g                  whether to use GSS-TSIG for UPDATE
 EOF
     exit 1;
 }
 my %opt;
-usage unless getopts '-hV01cCdDk:ns:S:vy:', \%opt;
+usage unless getopts '-hV01cCdDgk:ns:S:vy:', \%opt;
 version if $opt{V};
 exec "perldoc -F $0" if $opt{h};
 usage if @ARGV != 1;
@@ -67,6 +68,8 @@ push @nsdiff, "-slocalhost" unless $opt{s};
 push @nsdiff, "-u" if $opt{s};
 
 my @nsupdate = qw{nsupdate};
+push @nsupdate, map "-$_",
+    grep $opt{$_}, qw{g};
 push @nsupdate, map "-$_$opt{$_}",
     grep $opt{$_}, qw{k y};
 push @nsupdate, "-l" unless $opt{s};


### PR DESCRIPTION
Alongside regular TSIG, nsupdate has the `-g` option (and the `gsstsig` subcommand) to use GSS-TSIG aka Kerberos 5 authentication, which is supported by BIND and MS Active Directory.

nsvi should accept the -g option and forward it to nsupdate.

(There is no equivalent for dig, it seems.)