### PR TITLE
Use /usr/bin/env to fix running it on FreeBSD

### DIFF
--- a/nsdiff
+++ b/nsdiff
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # SPDX-License-Identifier: CC0-1.0
 
 use warnings;

--- a/nspatch
+++ b/nspatch
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # SPDX-License-Identifier: CC0-1.0
 
 use warnings;

--- a/nsvi
+++ b/nsvi
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # SPDX-License-Identifier: CC0-1.0
 
 use warnings;


### PR DESCRIPTION
Currently the scripts use /usr/bin/perl to run the scripts, but on FreeBSD perl is not in /usr/bin, so using /usr/bin/env perl will let the scripts also work on FreeBSD.